### PR TITLE
feat: persist outbox with indexeddb

### DIFF
--- a/pwa/src/app/outbox.ts
+++ b/pwa/src/app/outbox.ts
@@ -1,10 +1,37 @@
-export type OutboxItem = { id: string; url: string; body: any; createdAt: number };
-const mem: OutboxItem[] = [];
+import { openDB, type DBSchema } from 'idb';
 
-export async function queue(item: OutboxItem) { mem.push(item); }
+export type OutboxItem = { id: string; url: string; body: any; createdAt: number };
+
+interface OutboxDB extends DBSchema {
+  items: {
+    key: string;
+    value: OutboxItem;
+  };
+}
+
+const dbPromise = openDB<OutboxDB>('outbox', 1, {
+  upgrade(db) {
+    db.createObjectStore('items', { keyPath: 'id' });
+  },
+});
+
+export async function queue(item: OutboxItem) {
+  const db = await dbPromise;
+  await db.put('items', item);
+}
+
 export async function drain(sender: (it: OutboxItem) => Promise<void>) {
-  for (const it of [...mem]) {
-    try { await sender(it); const i = mem.findIndex(x => x.id === it.id); if (i >= 0) mem.splice(i,1); }
-    catch { /* keep for retry */ }
+  const db = await dbPromise;
+  const tx = db.transaction('items', 'readwrite');
+  let cursor = await tx.store.openCursor();
+  while (cursor) {
+    try {
+      await sender(cursor.value);
+      await cursor.delete();
+    } catch {
+      /* keep for retry */
+    }
+    cursor = await cursor.continue();
   }
+  await tx.done;
 }


### PR DESCRIPTION
## Summary
- use idb-backed IndexedDB store for offline outbox persistence
- expose queue and drain backed by database with cleanup on send

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac9da76ff48330a6bc9f5683adf696